### PR TITLE
remove a specific string from the title

### DIFF
--- a/lib/copyist/job.rb
+++ b/lib/copyist/job.rb
@@ -38,7 +38,7 @@ module Copyist
         next if skip_identifires && line.match?(skip_identifires)
 
         if line.match?(/^#{title_identifire}/)
-          tickets << IssueTicket.new(line.gsub(title_identifire, ''), [], [])
+          tickets << IssueTicket.new(line.gsub(/#{title_identifire}|\*|\*\*|`/, ''), [], [])
 
         elsif label_identifire && line.match?(/^#{label_identifire}/)
           (tickets&.last&.labels || []) << line.gsub(label_identifire, '').chomp.split(',').map(&:strip)

--- a/test/copyist/job_test.rb
+++ b/test/copyist/job_test.rb
@@ -9,7 +9,7 @@ module Copyist
 
     def test_that_it_returns_markdown
       markdown = <<~"DOC"
-        # level1
+        # **level1** *hoge* `fuga`
         ## level2
         ##### hoge - this line skip
         labels: frontend,backend
@@ -25,7 +25,7 @@ module Copyist
       target.stub(:get_markdown, markdown.scan(/.*\n/)) {
         result = target.tickets_from_markdown
 
-        assert result.first.title == "level1\n"
+        assert result.first.title == "level1 hoge fuga\n"
 
         assert result.first.description == <<~"RESULT"
         ## level2


### PR DESCRIPTION
- Implemented to remove formatting identifiers from ticket titles when they are included.